### PR TITLE
Make sure Find method takes into account server name

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -19,7 +19,7 @@ type serviceInfo struct {
 // Discovery provides service discovery interface
 type Discovery interface {
 	Register(server string, service interface{}) error
-	Find(v interface{}) error
+	Find(server string, v interface{}) error
 	ForEach(v interface{}, f func(typ string) error) error
 }
 
@@ -55,7 +55,7 @@ func (d *disco) Register(server string, service interface{}) error {
 }
 
 // Find interface
-func (d *disco) Find(v interface{}) error {
+func (d *disco) Find(server string, v interface{}) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {
 		return errors.Errorf("a pointer to interface is required, invalid type: %v", rv)
@@ -69,7 +69,7 @@ func (d *disco) Find(v interface{}) error {
 	}
 
 	for _, reg := range d.reg {
-		if reg.Type.Implements(rv.Type()) {
+		if reg.Type.Implements(rv.Type()) && reg.ServerName == server {
 			rv.Set(reflect.ValueOf(reg.Service))
 			return nil
 		}

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -24,7 +24,7 @@ func TestDiscovery(t *testing.T) {
 	require.EqualError(t, err, "already registered: TestDiscovery/*discovery_test.barImpl")
 
 	var f2 foo
-	err = d.Find(&f2)
+	err = d.Find(srv, &f2)
 	require.NoError(t, err)
 	require.NotNil(t, f2)
 	assert.Equal(t, f.GetName(), f2.GetName())
@@ -39,13 +39,13 @@ func TestDiscovery(t *testing.T) {
 	assert.Equal(t, 1, count)
 
 	var nonPointer bar
-	err = d.Find(nonPointer)
+	err = d.Find(srv, nonPointer)
 	require.EqualError(t, err, "a pointer to interface is required, invalid type: <invalid reflect.Value>")
 
-	err = d.Find(err)
+	err = d.Find(srv, err)
 	require.EqualError(t, err, "non interface type: *errors.fundamental")
 
-	err = d.Find(&err)
+	err = d.Find(srv, &err)
 	require.EqualError(t, err, "not implemented: <error Value>")
 
 	err = d.ForEach(nonPointer, func(key string) error {


### PR DESCRIPTION
when our services start they register themselves in [DiscoveryService](https://github.com/effective-security/porto/blob/d74f53913be95020819d660e4768ac642a634da4/pkg/discovery/discovery.go#L38).

pkg=discovery func=Register server="backend" type="*status.Service"
pkg=discovery func=Register server="backend" type="*backend.Service"

pkg=discovery func=Register server="wfe" type="*status.Service"
pkg=discovery func=Register server="wfe" type="*auth.Service"
pkg=discovery func=Register server="wfe" type="*orgs.Service"
pkg=discovery func=Register server="wfe" type="*reports.Service"
pkg=discovery func=Register server="wfe" type="*admin.Service"
Now both "*backend.Service" and "*admin.Service" implement "privpb.BackendServer" interface and when calling discovery Find method there is a chance that randomly one of this two types will be returned because Find method literally ignores whether it is backend or wfe and is implemented as dictionary 🙂 Notice the problem? We want Find method to return "*backend.Service" because returning "*admin.Service" will end up in infinite loop (stack overflow). We need to get rid of this randomness by either fixing the logic in Find method or rename methods in "*admin.Service" so that it does not implement "privpb.BackendServer" interface.

With this PR we make sure server name is considered when using Find method to avoid multiple results for the same interface type.
